### PR TITLE
Fix the hook sometimes being skipped

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,5 +3,4 @@
     description: Checks if commit message matches the chaos-hub commit rules
     entry: commit-msg-hook
     language: python
-    types: [text]
-  
+    always_run: true


### PR DESCRIPTION
The `commit-msg` hook should not depend on any particular file type, but in the implementation from version v.0.3.4 it checks the message only when committed files are text files. So it will skip checks entirely when the only files changed are ie. YAML files.